### PR TITLE
do timesstamp calculation in double because it might be negative 

### DIFF
--- a/src/Snapshotter.cpp
+++ b/src/Snapshotter.cpp
@@ -134,9 +134,11 @@ void Snapshotter::writeBagFile(const std::string& path, BagCompression compressi
             bag.open(path, bagmode::Write);
             /** write all old latched messages 3 seconds before the actual log starts.
              *  The value 3 is arbitrary. The idea is to make the old latched messages stand out
-             *  to a human reader when looking at the bag. */
-            const ros::Time latchedTime = bufferCopy->getOldestReceiveTime() - ros::Duration(3);
-            latchedBufferCopy->writeToBag(bag, latchedTime);
+             *  to a human reader when looking at the bag. We do the calculation in double because ros::Time will throw when
+             *  the time becomes negative (which can happen when running in simulation because sim time starts at 0) */
+            double latchedTime = bufferCopy->getOldestReceiveTime().toSec() - 3.0;
+            latchedTime = std::max(latchedTime, 0.0);
+            latchedBufferCopy->writeToBag(bag, ros::Time{latchedTime});
 
             bufferCopy->writeToBag(bag);
             bag.close();


### PR DESCRIPTION
When running in simulation messages might have a very small timestamp because simulation time starts at zero.
Old latched messages (i.e. latched messages from a time that is no longer present in the log) are inserted 3 seconds before the actual log starts. When such a message has a timestamp < 3.0 the time becomes negative.
ros::Time cannot handle negative numbers and throws. This patch fixes that.