### PR TITLE
fix: keep recording while writing

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -31,6 +31,8 @@ add_library(${PROJECT_NAME}_lib OBJECT
   src/TopicFilter.hpp
   src/SingleMessageBuffer.hpp
   src/SingleMessageBuffer.cpp
+  src/Node.hpp
+  src/Node.cpp
 )
 target_link_libraries(
     ${PROJECT_NAME}_lib

--- a/src/Node.cpp
+++ b/src/Node.cpp
@@ -1,0 +1,73 @@
+#include "Node.hpp"
+
+#include <chrono>
+
+namespace snapshotter
+{
+
+SnapshotNode::SnapshotNode(rclcpp::Node& nh, const snapshotter::Snapshotter::Config& cfg, BagCompression compression,
+                           const TopicFilter& topicFilter) :
+    snapshotter{nh, cfg},
+    nh{nh},
+    compression{compression},
+    topicFilter{topicFilter}
+{
+    subscribeTopics();
+
+    subscribeTimer = nh.create_wall_timer(std::chrono::seconds(2), [this]() { subscribeTopics(); });
+
+    service = nh.create_service<snapshotter::srv::TakeSnapshot>(
+        "take_snapshot", [&](const std::shared_ptr<rmw_request_id_t> header,
+                             snapshotter::srv::TakeSnapshot::Request::SharedPtr req) { handleRequest(header, req); });
+}
+
+void SnapshotNode::handleRequest(const std::shared_ptr<rmw_request_id_t> header,
+                                 const std::shared_ptr<snapshotter::srv::TakeSnapshot::Request> req)
+{
+    if (!takeSnapshotServiceLock.try_lock())
+    {
+        snapshotter::srv::TakeSnapshot::Response resp;
+        resp.message = "Already taking snapshot";
+        resp.success = false;
+        service->send_response(*header, resp);
+        return;
+    }
+
+    snapshotter.writeBagFile(req->filename, compression, [this, header](const std::optional<BagWriteException>& error) {
+        snapshotter::srv::TakeSnapshot::Response resp;
+        if (error)
+        {
+            resp.message = error->what();
+            resp.success = false;
+        }
+        else
+        {
+            resp.success = true;
+        }
+        try
+        {
+            service->send_response(*header, resp);
+        }
+        catch (...)
+        {
+            // catch everything because we need to make sure that the mutex is always unlocked
+            RCLCPP_ERROR_STREAM(nh.get_logger(), "Failed to send service response");
+        }
+        takeSnapshotServiceLock.unlock();
+    });
+}
+
+void SnapshotNode::subscribeTopics()
+{
+    std::map<std::string, std::vector<std::string>> allTopics = nh.get_topic_names_and_types();
+
+    for (const auto& [topicName, _] : allTopics)
+    {
+        if (!topicFilter.exclude(topicName))
+        {
+            snapshotter.subscribe(topicName);
+        }
+    }
+}
+
+} // namespace snapshotter

--- a/src/Node.cpp
+++ b/src/Node.cpp
@@ -7,10 +7,10 @@ namespace snapshotter
 
 SnapshotNode::SnapshotNode(rclcpp::Node& nh, const snapshotter::Snapshotter::Config& cfg, BagCompression compression,
                            const TopicFilter& topicFilter) :
-    snapshotter{nh, cfg},
     nh{nh},
     compression{compression},
-    topicFilter{topicFilter}
+    topicFilter{topicFilter},
+    snapshotter{nh, cfg}
 {
     subscribeTopics();
 
@@ -35,14 +35,10 @@ void SnapshotNode::handleRequest(const std::shared_ptr<rmw_request_id_t> header,
 
     snapshotter.writeBagFile(req->filename, compression, [this, header](const std::optional<BagWriteException>& error) {
         snapshotter::srv::TakeSnapshot::Response resp;
+        resp.success = !error.has_value();
         if (error)
         {
             resp.message = error->what();
-            resp.success = false;
-        }
-        else
-        {
-            resp.success = true;
         }
         try
         {

--- a/src/Node.hpp
+++ b/src/Node.hpp
@@ -1,0 +1,35 @@
+#pragma once
+#include "Snapshotter.hpp"
+#include "TopicFilter.hpp"
+#include <memory>
+#include <mutex>
+#include <rclcpp/node.hpp>
+#include <rclcpp/timer.hpp>
+#include <snapshotter/srv/take_snapshot.hpp>
+
+namespace snapshotter
+{
+
+class SnapshotNode
+{
+public:
+    SnapshotNode(rclcpp::Node& nh, const snapshotter::Snapshotter::Config& cfg, BagCompression compression,
+                 const TopicFilter& topicFilter);
+
+    void handleRequest(const std::shared_ptr<rmw_request_id_t> header,
+                       const std::shared_ptr<snapshotter::srv::TakeSnapshot::Request> req);
+
+private:
+    void subscribeTopics();
+
+    Snapshotter snapshotter;
+    rclcpp::Node& nh;
+    BagCompression compression;
+    TopicFilter topicFilter;
+
+    rclcpp::Service<snapshotter::srv::TakeSnapshot>::SharedPtr service;
+    std::mutex takeSnapshotServiceLock;
+    std::shared_ptr<rclcpp::TimerBase> subscribeTimer;
+};
+
+} // namespace snapshotter

--- a/src/Node.hpp
+++ b/src/Node.hpp
@@ -22,7 +22,6 @@ public:
 private:
     void subscribeTopics();
 
-    Snapshotter snapshotter;
     rclcpp::Node& nh;
     BagCompression compression;
     TopicFilter topicFilter;
@@ -30,6 +29,10 @@ private:
     rclcpp::Service<snapshotter::srv::TakeSnapshot>::SharedPtr service;
     std::mutex takeSnapshotServiceLock;
     std::shared_ptr<rclcpp::TimerBase> subscribeTimer;
+
+    // create snapshotter last to ensure that it is deleted first
+    // because the callback from the snapshotter will access the node
+    Snapshotter snapshotter;
 };
 
 } // namespace snapshotter

--- a/src/Snapshotter.cpp
+++ b/src/Snapshotter.cpp
@@ -34,6 +34,7 @@
 #include "Snapshotter.hpp"
 #include <cerrno>
 #include <chrono>
+#include <mutex>
 #include <optional>
 #include <rmw/rmw.h>
 #include <rosbag2_cpp/writer.hpp>
@@ -51,6 +52,15 @@ Snapshotter::Snapshotter(rclcpp::Node& nh, const Snapshotter::Config& cfg) :
     buffer(cfg.maxMemoryBytes, [this](BufferEntry&& e) { messageDroppedFromBufferCB(std::move(e)); }),
     log(nh.get_logger())
 {}
+
+Snapshotter::~Snapshotter()
+{
+    // take the writer lock so nobody can start a new write operation while
+    // we are being destructed
+    // This will also block until a currently running writer thread has finished to ensure that
+    // the callback can still be invoked
+    writerRunningLock.lock();
+}
 
 /// dumps the qos profiles from all endpoints into a yaml node
 std::string convertOfferedQosToYaml(const std::vector<rclcpp::TopicEndpointInfo>& endpointInfos)
@@ -138,8 +148,18 @@ void Snapshotter::writeBagFile(const std::string& path, BagCompression compressi
     // Thus it is much easier and safer to spawn a new thread and let
     // it die once we are done writing.
 
-    std::thread t([path, compression, cb, this]() {
+    std::unique_lock<std::mutex> lock(writerRunningLock, std::try_to_lock);
+    if (!lock.owns_lock())
+    {
+        cb(BagWriteException("Snapshotter is already writing a bag file"));
+        return;
+    }
+
+    writer = std::jthread([path, compression, cb, this, lock = std::move(lock)]() mutable {
         using namespace rosbag2_cpp;
+
+        // move lock to local scope to ensure that it is released when the lambda execution ends
+        auto localLock = std::move(lock);
 
         if (cfg.niceOnWrite)
         {
@@ -208,14 +228,16 @@ void Snapshotter::writeBagFile(const std::string& path, BagCompression compressi
             /** write all old latched messages 3 seconds before the actual log starts.
              *  The value 3 is arbitrary. The idea is to make the old latched messages stand out
              *  to a human reader when looking at the bag. We do the calculation in double because rclcpp::Time will
-             * throw when the time becomes negative (which can happen when running in simulation because sim time starts
-             * at 0) */
+             * throw when the time becomes negative (which can happen when running in simulation because sim time
+             * starts at 0) */
             rclcpp::Time latchedTime = bufferCopy->getOldestReceiveTime() - std::chrono::seconds(3);
             latchedTime = std::max(latchedTime, rclcpp::Time(static_cast<int64_t>(0), RCL_ROS_TIME));
             latchedBufferCopy->writeToBag(writer, metaData, latchedTime);
 
             bufferCopy->writeToBag(writer, metaData);
             writer.close();
+
+            cb(std::nullopt);
         }
         catch (const std::exception& e)
         {
@@ -228,10 +250,7 @@ void Snapshotter::writeBagFile(const std::string& path, BagCompression compressi
         const auto elapsedTime =
             std::chrono::duration_cast<std::chrono::milliseconds>(std::chrono::steady_clock::now() - startTime);
         RCLCPP_INFO_STREAM(log, "Writing took: " << elapsedTime.count() << " ms");
-
-        cb(std::nullopt);
     });
-    t.detach();
 }
 
 void Snapshotter::topicCB(const SerializedMsgPtr& msg, const TopicMetadata& md)

--- a/src/Snapshotter.cpp
+++ b/src/Snapshotter.cpp
@@ -34,6 +34,7 @@
 #include "Snapshotter.hpp"
 #include <cerrno>
 #include <chrono>
+#include <optional>
 #include <rmw/rmw.h>
 #include <rosbag2_cpp/writer.hpp>
 #include <rosbag2_cpp/writers/sequential_writer.hpp>
@@ -125,58 +126,9 @@ bool Snapshotter::subscribe(const std::string& topic)
     return true;
 }
 
-void Snapshotter::writeBagFile(const std::string& path, BagCompression compression)
+void Snapshotter::writeBagFile(const std::string& path, BagCompression compression, const WriteDoneCb& cb)
 {
-    using namespace rosbag2_cpp;
-
-    const auto startTime = std::chrono::steady_clock::now();
-
-    std::unique_ptr<rosbag2_cpp::writer_interfaces::BaseWriterInterface> writerImpl;
-    writerImpl = std::make_unique<rosbag2_cpp::writers::SequentialWriter>();
-    rosbag2_cpp::Writer writer(std::move(writerImpl));
-
-    rosbag2_storage::StorageOptions storageOpts{};
-    storageOpts.uri = path;
-
-    switch (compression)
-    {
-        case BagCompression::FAST:
-        {
-            storageOpts.storage_preset_profile = "zstd_fast";
-        }
-        break;
-        case BagCompression::SLOW:
-        {
-            storageOpts.storage_preset_profile = "zstd_small";
-        }
-        break;
-        case BagCompression::NONE:
-            break;
-        default:
-            throw BagWriteException("Unhandled enum value");
-    }
-
-    std::unique_ptr<MessageRingBuffer> bufferCopy;
-    std::unique_ptr<SingleMessageBuffer> latchedBufferCopy;
-    {
-        // wait until all threads have stopped writing to the buffers,
-        // then copy both buffers
-        std::unique_lock lock(writeBagLock);
-        bufferCopy = std::make_unique<MessageRingBuffer>(buffer);
-        latchedBufferCopy = std::make_unique<SingleMessageBuffer>(lastDroppedLatchedMsgs);
-    }
-
-    std::vector<TopicMetadata> metaData;
-    {
-        std::unique_lock l(metaDataLock);
-        metaData = topicMetadata;
-    }
-
-    // replace the dropped-callback of the copied buffer. Otherwise dropped messages
-    // from that buffer would end up in the original lastDroppedLatchedMsgs buffer.
-    bufferCopy->setDroppedCb([](BufferEntry&&) {});
-
-    // writing is done in a seperate thread because errors might happen
+    // writing is done in a separate thread because errors might happen
     // during writing and there is no guaranteed way to reset the
     // thread priority once an error occurred. If we would use one
     // of the ros threads we would leave a ros thread with very low
@@ -185,24 +137,72 @@ void Snapshotter::writeBagFile(const std::string& path, BagCompression compressi
     // priority could still fail (and in fact did fail on my machine).
     // Thus it is much easier and safer to spawn a new thread and let
     // it die once we are done writing.
-    std::exception_ptr ex = nullptr;
-    std::thread t([&] {
+
+    std::thread t([path, compression, cb, this]() {
+        using namespace rosbag2_cpp;
+
+        if (cfg.niceOnWrite)
+        {
+            // according to 'man setpriority' this call is not POSIX conform, and sets the priority
+            // for this thread and all of its child threads. This exactly what we want.
+            errno = 0;
+            if (0 != setpriority(PRIO_PROCESS, 0, 19) || errno != 0)
+            {
+                const std::string msg = "setpriority failed: " + std::string(std::strerror(errno));
+                RCLCPP_ERROR_STREAM(log, msg);
+                cb(BagWriteException(msg));
+                return;
+            }
+        }
+
+        const auto startTime = std::chrono::steady_clock::now();
+
+        std::unique_ptr<rosbag2_cpp::writer_interfaces::BaseWriterInterface> writerImpl;
+        writerImpl = std::make_unique<rosbag2_cpp::writers::SequentialWriter>();
+        rosbag2_cpp::Writer writer(std::move(writerImpl));
+
+        rosbag2_storage::StorageOptions storageOpts{};
+        storageOpts.uri = path;
+
+        switch (compression)
+        {
+            case BagCompression::FAST:
+            {
+                storageOpts.storage_preset_profile = "zstd_fast";
+            }
+            break;
+            case BagCompression::SLOW:
+            {
+                storageOpts.storage_preset_profile = "zstd_small";
+            }
+            break;
+            case BagCompression::NONE:
+                break;
+        }
+
+        // copy the buffers to allow the snapshotter to continue recording while we write
+        std::unique_ptr<MessageRingBuffer> bufferCopy;
+        std::unique_ptr<SingleMessageBuffer> latchedBufferCopy;
+        {
+            // wait until all threads have stopped writing to the buffers,
+            // then copy both buffers
+            std::unique_lock lock(writeBagLock);
+            bufferCopy = std::make_unique<MessageRingBuffer>(buffer);
+            latchedBufferCopy = std::make_unique<SingleMessageBuffer>(lastDroppedLatchedMsgs);
+        }
+
+        std::vector<TopicMetadata> metaData;
+        {
+            std::unique_lock l(metaDataLock);
+            metaData = topicMetadata;
+        }
+
+        // replace the dropped-callback of the copied buffer. Otherwise dropped messages
+        // from that buffer would end up in the original lastDroppedLatchedMsgs buffer.
+        bufferCopy->setDroppedCb([](BufferEntry&&) {});
+
         try
         {
-            if (cfg.niceOnWrite)
-            {
-                // according to 'man setpriority' this call is not POSIX conform, and sets the priority
-                // for this thread and all of its child threads. This exactly what we want.
-                errno = 0;
-                if (0 != setpriority(PRIO_PROCESS, 0, 19) || errno != 0)
-                {
-                    const std::string msg = "setpriority failed: " + std::string(std::strerror(errno));
-                    RCLCPP_ERROR_STREAM(log, msg);
-                    ex = std::make_exception_ptr(BagWriteException(msg));
-                    return;
-                }
-            }
-
             writer.open(storageOpts);
 
             /** write all old latched messages 3 seconds before the actual log starts.
@@ -219,23 +219,19 @@ void Snapshotter::writeBagFile(const std::string& path, BagCompression compressi
         }
         catch (const std::exception& e)
         {
-            ex = std::make_exception_ptr(BagWriteException(e.what()));
+            cb(BagWriteException(e.what()));
         }
         catch (...) // we really really don't want to crash :D
         {
-            ex = std::make_exception_ptr(BagWriteException("unknown error"));
+            cb(BagWriteException("unknown error"));
         }
+        const auto elapsedTime =
+            std::chrono::duration_cast<std::chrono::milliseconds>(std::chrono::steady_clock::now() - startTime);
+        RCLCPP_INFO_STREAM(log, "Writing took: " << elapsedTime.count() << " ms");
+
+        cb(std::nullopt);
     });
-    t.join();
-
-    const auto elapsedTime =
-        std::chrono::duration_cast<std::chrono::milliseconds>(std::chrono::steady_clock::now() - startTime);
-    RCLCPP_INFO_STREAM(log, "Writing took: " << elapsedTime.count() << " ms");
-
-    if (ex)
-    {
-        std::rethrow_exception(ex);
-    }
+    t.detach();
 }
 
 void Snapshotter::topicCB(const SerializedMsgPtr& msg, const TopicMetadata& md)

--- a/src/Snapshotter.hpp
+++ b/src/Snapshotter.hpp
@@ -61,9 +61,13 @@ public:
      *  If the topic is already subscribed nothing will happen. */
     bool subscribe(const std::string& topic);
 
-    /**Stops recording, writes the bag and restarts recording
-     * @throw BagWriteException in case of error */
-    void writeBagFile(const std::string& path, BagCompression compression);
+    using WriteDoneCb = std::function<void(const std::optional<BagWriteException>&)>;
+
+    /** async writes the bag file.
+     *  Recording of data continues while writing.
+     *  This method is not blocking.
+     *  @param cb will be invoked when the writing is either done or an error occurred*/
+    void writeBagFile(const std::string& path, BagCompression compression, const WriteDoneCb& cb);
 
 private:
     void topicCB(const SerializedMsgPtr& msg, const TopicMetadata& md);

--- a/src/Snapshotter.hpp
+++ b/src/Snapshotter.hpp
@@ -35,8 +35,11 @@
 #include "Common.hpp"
 #include "MessageRingBuffer.hpp"
 #include "SingleMessageBuffer.hpp"
+#include <atomic>
+#include <memory>
 #include <rclcpp/node.hpp>
 #include <shared_mutex>
+#include <thread>
 #include <unordered_set>
 #include <vector>
 
@@ -57,16 +60,23 @@ public:
 
     Snapshotter(rclcpp::Node& nh, const Config& cfg);
 
+    /** The destructor will block until the currently running write operation has finished. */
+    ~Snapshotter();
+
     /** The snapshotter will subscribe to the given @p topic and log it.
      *  If the topic is already subscribed nothing will happen. */
     bool subscribe(const std::string& topic);
 
-    using WriteDoneCb = std::function<void(const std::optional<BagWriteException>&)>;
+    /** The callback will be invoked when the writing is either done or an error occurred.
+     *  It will be invoked from a different thread than the one that called writeBagFile.
+     *  @note The callback may not throw an exception.
+     *  @p error will contain the error, if any error occurred. If writing finished successfully it will be nullopt.*/
+    using WriteDoneCb = std::function<void(const std::optional<BagWriteException>& error)>;
 
     /** async writes the bag file.
      *  Recording of data continues while writing.
      *  This method is not blocking.
-     *  @param cb will be invoked when the writing is either done or an error occurred*/
+     *  @param cb will be invoked when the writing is either done or an error occurred.*/
     void writeBagFile(const std::string& path, BagCompression compression, const WriteDoneCb& cb);
 
 private:
@@ -87,6 +97,11 @@ private:
     std::vector<TopicMetadata> topicMetadata;
 
     rclcpp::Logger log;
+
+    /** used to ensure that only one write operation is in progress at a time */
+    std::mutex writerRunningLock;
+    /** The thread used for all write operations */
+    std::jthread writer;
 };
 
 } // namespace snapshotter

--- a/src/main.cpp
+++ b/src/main.cpp
@@ -35,12 +35,12 @@
 #include "Snapshotter.hpp"
 #include "TopicFilter.hpp"
 
+#include "Node.hpp"
 #include <rclcpp/executors.hpp>
 #include <rclcpp/logging.hpp>
 #include <rclcpp/node.hpp>
+#include <rclcpp/timer.hpp>
 #include <snapshotter/srv/take_snapshot.hpp>
-
-#include <mutex>
 #include <string>
 #include <vector>
 
@@ -138,60 +138,9 @@ int main(int argc, char** argv)
     cfg.maxMemoryBytes = size_t(maxMemoryMb) * size_t(1024 * 1024);
     cfg.niceOnWrite = nh.get_parameter("nice_on_write").as_bool();
 
-    Snapshotter snapshotter(nh, cfg);
-
-    std::function<void()> subscribeTopics = [&snapshotter, &topicFilter, &nh]() {
-        std::map<std::string, std::vector<std::string>> allTopics = nh.get_topic_names_and_types();
-
-        for (const auto& [topicName, _] : allTopics)
-        {
-            if (!topicFilter.exclude(topicName))
-            {
-                snapshotter.subscribe(topicName);
-            }
-        }
-    };
-    // call once to immediately subscribe to all available topics
-    subscribeTopics();
-    auto topicCheck = nh.create_wall_timer(std::chrono::seconds(2), subscribeTopics);
-
     BagCompression compression = getCompression(nh);
 
-    std::mutex takeSnapshotServiceLock;
-
-    std::function<bool(snapshotter::srv::TakeSnapshot::Request::SharedPtr,
-                       snapshotter::srv::TakeSnapshot::Response::SharedPtr)>
-        takeSnapshotCb = [&](snapshotter::srv::TakeSnapshot::Request::SharedPtr req,
-                             snapshotter::srv::TakeSnapshot::Response::SharedPtr resp) {
-            std::unique_lock<std::mutex> lock(takeSnapshotServiceLock, std::try_to_lock);
-            if (!lock.owns_lock())
-            {
-                // mutex wasn't locked. Handle it.
-                resp->success = false;
-                resp->message = "Already taking a snapshot.";
-                return true;
-            }
-
-            try
-            {
-                snapshotter.writeBagFile(req->filename, compression);
-                resp->success = true;
-            }
-            catch (const std::exception& e)
-            {
-                RCLCPP_ERROR_STREAM(nh.get_logger(), "Got exception while writing bag : " << e.what());
-                resp->message = e.what();
-                resp->success = false;
-            }
-            catch (...)
-            {
-                resp->message = "unknown error";
-                resp->success = false;
-            }
-
-            return true;
-        };
-    auto service = nh.create_service<snapshotter::srv::TakeSnapshot>("take_snapshot", takeSnapshotCb);
+    snapshotter::SnapshotNode node{nh, cfg, compression, topicFilter};
 
     rclcpp::executors::SingleThreadedExecutor executor;
     executor.add_node(nh.get_node_base_interface());
@@ -204,5 +153,6 @@ int main(int argc, char** argv)
         executor.spin_some();
         processRate.sleep();
     }
+
     return 0;
 }

--- a/test/test_node.cpp
+++ b/test/test_node.cpp
@@ -2,7 +2,9 @@
 #include "Common.hpp"
 #include "Snapshotter.hpp"
 #include <filesystem>
+#include <future>
 #include <gtest/gtest.h>
+#include <optional>
 #include <rclcpp/executors.hpp>
 #include <rclcpp/node.hpp>
 #include <rosbag2_cpp/reader.hpp>
@@ -279,8 +281,13 @@ TEST(TestSuite, SimpleTest)
     pub.run();
 
     const std::string file = getLogFileName();
-    snapshotter.writeBagFile(file, BagCompression::NONE);
-
+    std::promise<std::optional<BagWriteException>> writeDonePromise;
+    auto writeDoneFuture = writeDonePromise.get_future();
+    snapshotter.writeBagFile(file, BagCompression::NONE, [&](const std::optional<BagWriteException>& maybeError) {
+        writeDonePromise.set_value(maybeError);
+    });
+    ASSERT_EQ(writeDoneFuture.wait_for(std::chrono::seconds(20)), std::future_status::ready);
+    ASSERT_FALSE(writeDoneFuture.get().has_value());
     pub.checkBoolMsgs(file, false);
     pub.checkFloatMsgs(file, false);
 }
@@ -302,7 +309,14 @@ TEST(TestSuite, DropAllMsgs)
     pub.run();
 
     const std::string file = getLogFileName();
-    snapshotter.writeBagFile(file, BagCompression::NONE);
+    std::promise<std::optional<BagWriteException>> writeDonePromise;
+    auto writeDoneFuture = writeDonePromise.get_future();
+    snapshotter.writeBagFile(file, BagCompression::NONE,
+                             [&writeDonePromise](const std::optional<BagWriteException>& maybeError) {
+                                 writeDonePromise.set_value(maybeError);
+                             });
+    ASSERT_EQ(writeDoneFuture.wait_for(std::chrono::seconds(20)), std::future_status::ready);
+    ASSERT_FALSE(writeDoneFuture.get().has_value());
 
     rosbag2_cpp::Reader reader;
     reader.open(file);
@@ -333,7 +347,14 @@ TEST(TestSuite, DropSomeMsgs)
     pub.run();
 
     const std::string file = getLogFileName();
-    snapshotter.writeBagFile(file, BagCompression::NONE);
+    std::promise<std::optional<BagWriteException>> writeDonePromise;
+    auto writeDoneFuture = writeDonePromise.get_future();
+    snapshotter.writeBagFile(file, BagCompression::NONE,
+                             [&writeDonePromise](const std::optional<BagWriteException>& maybeError) {
+                                 writeDonePromise.set_value(maybeError);
+                             });
+    ASSERT_EQ(writeDoneFuture.wait_for(std::chrono::seconds(20)), std::future_status::ready);
+    ASSERT_FALSE(writeDoneFuture.get().has_value());
 
     rosbag2_cpp::Reader reader;
     reader.open(file);
@@ -383,7 +404,14 @@ TEST(TestSuite, Latched)
     pub.run();
 
     const std::string file = getLogFileName();
-    snapshotter.writeBagFile(file, BagCompression::NONE);
+    std::promise<std::optional<BagWriteException>> writeDonePromise;
+    auto writeDoneFuture = writeDonePromise.get_future();
+    snapshotter.writeBagFile(file, BagCompression::NONE,
+                             [&writeDonePromise](const std::optional<BagWriteException>& maybeError) {
+                                 writeDonePromise.set_value(maybeError);
+                             });
+    ASSERT_EQ(writeDoneFuture.wait_for(std::chrono::seconds(20)), std::future_status::ready);
+    ASSERT_FALSE(writeDoneFuture.get().has_value());
 
     rosbag2_cpp::Reader reader;
     reader.open(file);


### PR DESCRIPTION
This fixes a bug where no new data is recorded during writing because of the single threaded nature of the process. The writeBagFile was blocked by the join() method. This blocked the executor and no new messages where received while writing.